### PR TITLE
権限がある時のみボタンを表示、エラーページ(403,404)の作成

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
+	
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig {
 			.authorizeHttpRequests(authorize -> authorize
 		    	.requestMatchers(PathRequest.toStaticResources().atCommonLocations()) 
 		    	.permitAll().mvcMatchers("/").permitAll().mvcMatchers("/edit").permitAll()
-		    	.mvcMatchers("/admin").hasAuthority("ADMIN").anyRequest().authenticated());
+		    	.mvcMatchers("/admin").hasAuthority("ROLE_ADMIN")
+		    	.anyRequest().authenticated());
 		return http.build();
 	}
 

--- a/src/main/java/com/example/demo/controller/UserController.java
+++ b/src/main/java/com/example/demo/controller/UserController.java
@@ -34,7 +34,6 @@ public class UserController {
 		userService.insertOne(userForm);
 		return "redirect:/index";
 	}
+	
 }
-
-
 

--- a/src/main/java/com/example/demo/domain/UserModel.java
+++ b/src/main/java/com/example/demo/domain/UserModel.java
@@ -17,7 +17,6 @@ public class UserModel implements UserDetails {
 	private String username;
 	private String password;
 	private String roles;
-	Collection<? extends GrantedAuthority> getAuthorities;
 
 	@Override
 	public String getPassword() {
@@ -70,13 +69,12 @@ public class UserModel implements UserDetails {
 		// 認証とロールの付与
 		Collection<GrantedAuthority> authorityList = new ArrayList<>();
 		if ("ADMIN".equals(roles)) {
-			authorityList.add(new SimpleGrantedAuthority("ADMIN"));
+			authorityList.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
 		} else if ("USER".equals(roles)) {
-			authorityList.add(new SimpleGrantedAuthority("USER"));
+			authorityList.add(new SimpleGrantedAuthority("ROLE_USER"));
 		}
 		return authorityList;
 	}
-	
-}
 
+}
 

--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -1,0 +1,3 @@
+<div>403 Access Denied</div>
+<p>アクセス拒否</p>
+<a th:href="@{/hello}">Home</a>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,3 @@
+<div>404 Not Found</div>
+<p>ページが見つかりません</p>
+<a th:href="@{/hello}">Home</a>

--- a/src/main/resources/templates/hello.html
+++ b/src/main/resources/templates/hello.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org"
-	xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity5">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+	xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity5">
 
 <head>
 	<title>Hello World!</title>
@@ -12,9 +12,8 @@
 	<form th:action="@{/logout}" method="post">
 		<input type="submit" value="Sign Out" />
 	</form>
-	<div sec:authorize="hasRole('ADMIN')">
-		<a th:href="@{/admin}">管理者ページへ</a>
-	</div>
+
+	<a sec:authorize="hasAuthority('ROLE_ADMIN')" th:href="@{/admin}">管理者ページへ</a>
 </body>
 
 </html>

--- a/src/main/resources/templates/hello.html
+++ b/src/main/resources/templates/hello.html
@@ -1,15 +1,20 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org"
-      xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity5">
-  <head>
-    <title>Hello World!</title>
-  </head>
-  <body>
-    <h1 th:inline="text">Hello [[${#httpServletRequest.remoteUser}]]!</h1>
+	xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity5">
 
-    <form th:action="@{/logout}" method="post">
-      <input type="submit" value="Sign Out"/>
-    </form>
-    <a sec:authorize="hasAuthority('ADMIN')" th:href="@{/admin}">管理者ページへ</a>
-  </body>
+<head>
+	<title>Hello World!</title>
+</head>
+
+<body>
+	<h1 th:inline="text">Hello [[${#httpServletRequest.remoteUser}]]!</h1>
+
+	<form th:action="@{/logout}" method="post">
+		<input type="submit" value="Sign Out" />
+	</form>
+	<div sec:authorize="hasRole('ADMIN')">
+		<a th:href="@{/admin}">管理者ページへ</a>
+	</div>
+</body>
+
 </html>


### PR DESCRIPTION
403ページ
ロールを持ってない場合に遷移するページ。
Home(/hello)に戻れるボタンの追加。

404ページ
遷移するアドレスがない場合用のページ。
Home(/hello)に戻れるボタンの追加。

権限がある時のみボタンを表示
 UserModel#getAuthorities()の返り値はADMINではなく、ROLE_ADMINにしないと
tymeleafのsec:authorizeが機能しなかった。
返り値の変更に伴い、SecurityConfigのhasAuthority("ADMIN")もhasAuthority("ROLE_ADMIN")に変更